### PR TITLE
fix: \mytableマクロを変更。表を挿入したときに付けられるキャプションを、表の下から表の上にした

### DIFF
--- a/style.sty
+++ b/style.sty
@@ -144,8 +144,8 @@
 \newcommand{\mytable}[3]{
     \begin{table}[htb]
         \begin{center}
-            #3
             \caption{#1}
+            #3
             \label{tab:#2}
         \end{center}
     \end{table}


### PR DESCRIPTION
# 緊急性は？
無いです。来年のためって感じ

# 概要
タイトルの通りです。
`style.sty` ファイルでLaTeXのカスタムマクロが定義されているのですが、そのマクロの挙動を変更しました。
このように表のキャプションが下になっていたのを、
<img width="194" alt="Screenshot 2024-01-26 at 00 57 27" src="https://github.com/cpslab/Graduation-thesis-template2023/assets/49393637/ab89c993-894d-421c-b8b9-88cb0132c3fa">

このように、上に付くようにしました。
<img width="200" alt="Screenshot 2024-01-26 at 00 50 06" src="https://github.com/cpslab/Graduation-thesis-template2023/assets/49393637/94615b28-9385-47a9-8865-df98589b50a7">


## なぜ？
卒論のチェックシートに、表のキャプションは「表の上」に配置するよう書かれているからです。
<img width="500" alt="Screenshot 2024-01-26 at 00 49 32" src="https://github.com/cpslab/Graduation-thesis-template2023/assets/49393637/9e25473d-d66e-4bb1-96a3-e0b4166c81e4">

