### PR TITLE
fix:目次で表番号が通しにならないので修正

### DIFF
--- a/main_thesis.tex
+++ b/main_thesis.tex
@@ -27,6 +27,7 @@
 
 %% chapter との親子関係を解消
 \delete{figure}{chapter}
+\delete{table}{chapter}
 
 \begin{document}
 


### PR DESCRIPTION
gomaに感化されて、表が通し番号にならない不具合を修正
https://iwailab.slack.com/archives/C047ASBL0QJ/p1706179190932579
